### PR TITLE
Zone Component

### DIFF
--- a/examples/src/examples/physics/raycast.tsx
+++ b/examples/src/examples/physics/raycast.tsx
@@ -182,7 +182,7 @@ class RaycastExample {
                         app.drawLine(start, end, white);
 
                         const results = app.systems.rigidbody.raycastAll(start, end);
-                        results.forEach(function (result: pc.RaycastResult) {
+                        results.forEach(function (result: pc.HitResult) {
                             result.entity.render.material = red;
 
                             // Render the normal on the surface from the hit point

--- a/src/deprecated/deprecated.js
+++ b/src/deprecated/deprecated.js
@@ -115,7 +115,7 @@ import {
     BODYTYPE_DYNAMIC, BODYTYPE_KINEMATIC, BODYTYPE_STATIC
 } from '../framework/components/rigid-body/constants.js';
 import { RigidBodyComponent } from '../framework/components/rigid-body/component.js';
-import { RigidBodyComponentSystem } from '../framework/components/rigid-body/system.js';
+import { RigidBodyComponentSystem, HitResult } from '../framework/components/rigid-body/system.js';
 import { basisInitialize } from '../framework/handlers/basis.js';
 
 // CORE
@@ -1204,7 +1204,7 @@ Object.defineProperty(MouseEvent.prototype, 'wheel', {
 });
 
 // FRAMEWORK
-
+export const RaycastResult = HitResult;
 export const RIGIDBODY_TYPE_STATIC = BODYTYPE_STATIC;
 export const RIGIDBODY_TYPE_DYNAMIC = BODYTYPE_DYNAMIC;
 export const RIGIDBODY_TYPE_KINEMATIC = BODYTYPE_KINEMATIC;

--- a/src/framework/components/collision/component.js
+++ b/src/framework/components/collision/component.js
@@ -55,6 +55,7 @@ const _quat = new Quat();
  * an asset id. Defaults to null. If not set then the asset property will be checked instead.
  * @property {import('../../../scene/model.js').Model} model The model that is added to the scene
  * graph for the mesh collision volume.
+ * @property {boolean} zoneCheck Whether this collider should be used to detect if entity is within zone. Defaults to false.
  * @augments Component
  */
 class CollisionComponent extends Component {

--- a/src/framework/components/collision/data.js
+++ b/src/framework/components/collision/data.js
@@ -13,6 +13,7 @@ class CollisionComponentData {
         this.height = 2;
         this.asset = null;
         this.renderAsset = null;
+        this.zoneCheck = false;
 
         // Non-serialized properties
         this.shape = null;

--- a/src/framework/components/collision/system.js
+++ b/src/framework/components/collision/system.js
@@ -35,7 +35,8 @@ const _schema = [
     'renderAsset',
     'shape',
     'model',
-    'render'
+    'render',
+    'zoneCheck'
 ];
 
 // Collision system implementations
@@ -205,7 +206,8 @@ class CollisionSystemImpl {
             asset: src.data.asset,
             renderAsset: src.data.renderAsset,
             model: src.data.model,
-            render: src.data.render
+            render: src.data.render,
+            zoneCheck: src.data.zoneCheck
         };
 
         return this.system.addComponent(clone, data);
@@ -607,7 +609,8 @@ class CollisionComponentSystem extends ComponentSystem {
             'renderAsset',
             'enabled',
             'linearOffset',
-            'angularOffset'
+            'angularOffset',
+            'zoneCheck'
         ];
 
         // duplicate the input data because we are modifying it

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -334,10 +334,10 @@ class ZoneComponent extends Component {
                         // Entity was already in zone.
                         continue;
                     } else if (collidingIndex !== -1) {
+                        this.entities.push(entity);
                         // Entity entered zone.
                         entity.fire('zoneEnter', this);
                         this.fire('entityEnter', entity);
-                        this.entities.push(entity);
                     } else if (inZoneIndex !== -1) {
                         this.entities.splice(inZoneIndex, 1);
                         // Entity left zone.

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -4,7 +4,7 @@ import { Mat4 } from '../../../core/math/mat4.js';
 import { Component } from '../component.js';
 
 const _matrix = new Mat4();
-// Magnopus Patched
+
 /**
  * The ZoneComponent allows you to define an area in world space of certain size. This can be used
  * in various ways, such as affecting audio reverb when {@link AudioListenerComponent} is within
@@ -102,7 +102,7 @@ class ZoneComponent extends Component {
      */
 
     /**
-     * Fired when an entity enters the zone.
+     * Fired after an entity enters the zone.
      *
      * @event ZoneComponent#entityEnter
      * @param {import('../../entity').Entity} entity - The entity entering the zone.
@@ -113,7 +113,7 @@ class ZoneComponent extends Component {
      */
 
     /**
-     * Fired when an entity leaves the zone.
+     * Fired after an entity leaves the zone.
      *
      * @event ZoneComponent#entityLeave
      * @param {import('../../entity').Entity} entity - The entity leaving the zone.
@@ -334,13 +334,13 @@ class ZoneComponent extends Component {
                         // Entity was already in zone.
                         continue;
                     } else if (collidingIndex !== -1) {
-                        this.entities.push(entity);
                         // Entity entered zone.
+                        this.entities.push(entity);
                         entity.fire('zoneEnter', this);
                         this.fire('entityEnter', entity);
                     } else if (inZoneIndex !== -1) {
-                        this.entities.splice(inZoneIndex, 1);
                         // Entity left zone.
+                        this.entities.splice(inZoneIndex, 1);
                         entity.fire('zoneLeave', this);
                         this.fire('entityLeave', entity);
                     }
@@ -372,11 +372,12 @@ class ZoneComponent extends Component {
         this._destroyCollisionShape();
         this._toggleLifecycleListeners('off');
 
-        for (let i = 0, l = this.entities.length; i < l; i++) {
-            this.entities[i].fire('zoneLeave', this);
-        }
-
+        const entities = [...this.entities];
         this.entities.length = 0;
+
+        for (let i = 0, l = entities.length; i < l; i++) {
+            entities[i].fire('zoneLeave', this);
+        }
     }
 
     /**

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -4,7 +4,7 @@ import { Mat4 } from '../../../core/math/mat4.js';
 import { Component } from '../component.js';
 
 const _matrix = new Mat4();
-
+// Magnopus Patched
 /**
  * The ZoneComponent allows you to define an area in world space of certain size. This can be used
  * in various ways, such as affecting audio reverb when {@link AudioListenerComponent} is within

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -294,9 +294,9 @@ class ZoneComponent extends Component {
 
             if (this._isPointInZone(entity.getPosition(), position, rotation, _matrix)) {
                 if (index === -1) {
+                    this.entities.push(entity);
                     entity.fire('zoneEnter', this);
                     this.fire('entityEnter', entity);
-                    this.entities.push(entity);
                 }
             } else if (this.useColliders && entity.collision && entity.collision.enabled && entity.collision.zoneCheck) {
                 if (!pendingCollider) {
@@ -305,9 +305,9 @@ class ZoneComponent extends Component {
 
                 pendingCollider.push(entity);
             } else if (index !== -1) {
+                this.entities.splice(index, 1);
                 entity.fire('zoneLeave', this);
                 this.fire('entityleave', entity);
-                this.entities.splice(index, 1);
             }
         }
 
@@ -339,10 +339,10 @@ class ZoneComponent extends Component {
                         this.fire('entityEnter', entity);
                         this.entities.push(entity);
                     } else if (inZoneIndex !== -1) {
+                        this.entities.splice(inZoneIndex, 1);
                         // Entity left zone.
                         entity.fire('zoneLeave', this);
                         this.fire('entityLeave', entity);
-                        this.entities.splice(inZoneIndex, 1);
                     }
                 }
             }

--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -1,6 +1,9 @@
 import { Vec3 } from '../../../core/math/vec3.js';
+import { Mat4 } from '../../../core/math/mat4.js';
 
 import { Component } from '../component.js';
+
+const _matrix = new Mat4();
 
 /**
  * The ZoneComponent allows you to define an area in world space of certain size. This can be used
@@ -9,24 +12,45 @@ import { Component } from '../component.js';
  * performance reasons. And many other possible options. Zones are building blocks and meant to be
  * used in many different ways.
  *
+ * @property {"box"|"sphere"} shape The shape of this zone. Can be a `box` or a `sphere`.
+ * @property {Vec3} halfExtents The half-extents of the box-shaped zone in the x, y and z axes. Defaults to [0.5, 0.5, 0.5].
+ * @property {number} radius The radius of the sphere-shaped zone. Defaults to 0.5.
+ * @property {boolean} useColliders Whether the zone should look for colliders collision if entity is outside of it. Defaults to false.
  * @augments Component
- * @ignore
  */
 class ZoneComponent extends Component {
     /**
-     * Create a new ZoneComponent instance.
+     * The list of entities currently inside this zone.
+     *
+     * @type {import('../../entity').Entity[]}
+     */
+    entities = [];
+
+    /**
+     * The collision shape for this zone.
+     *
+     * @type {Ammo.btCollisionShape|null}
+     * @private
+     */
+    _collisionShape = null;
+
+    /**
+     * Last value of halfExtents.
+     *
+     * @type {Vec3}
+     * @ignore
+     */
+    _halfExtentsLast = new Vec3();
+
+    /**
+     * Create a new RigidBodyComponent instance.
      *
      * @param {import('./system.js').ZoneComponentSystem} system - The ComponentSystem that
-     * created this Component.
-     * @param {import('../../entity.js').Entity} entity - The Entity that this Component is
-     * attached to.
+     * created this component.
+     * @param {import('../../entity.js').Entity} entity - The entity this component is attached to.
      */
-    constructor(system, entity) {
+    constructor(system, entity) { // eslint-disable-line no-useless-constructor
         super(system, entity);
-
-        this._oldState = true;
-        this._size = new Vec3();
-        this.on('set_enabled', this._onSetEnabled, this);
     }
 
     /**
@@ -78,47 +102,290 @@ class ZoneComponent extends Component {
      */
 
     /**
-     * The size of the axis-aligned box of this ZoneComponent.
+     * Fired when an entity enters the zone.
      *
-     * @type {Vec3}
+     * @event ZoneComponent#entityEnter
+     * @param {import('../../entity').Entity} entity - The entity entering the zone.
+     * @example
+     * entity.zone.on('entityEnter', function (entity) {
+     *     // entity entered the zone
+     * });
      */
-    set size(data) {
-        if (data instanceof Vec3) {
-            this._size.copy(data);
-        } else if (data instanceof Array && data.length >= 3) {
-            this.size.set(data[0], data[1], data[2]);
+
+    /**
+     * Fired when an entity leaves the zone.
+     *
+     * @event ZoneComponent#entityLeave
+     * @param {import('../../entity').Entity} entity - The entity leaving the zone.
+     * @example
+     * entity.zone.on('entityLeave', function (entity) {
+     *     // entity left the zone
+     * });
+     */
+
+    /**
+     * Toggle life cycle listeners for this component.
+     *
+     * @param {"on"|"off"} onOrOff - Function to use.
+     * @private
+     */
+    _toggleLifecycleListeners(onOrOff) {
+        this[onOrOff]('set_useColliders', this._onSetUseColliders, this);
+        this[onOrOff]('set_shape', this._onSetShape, this);
+        this[onOrOff]('set_halfExtents', this._onSetHalfExtents, this);
+        this[onOrOff]('set_radius', this._onSetRadius, this);
+    }
+
+    /**
+     * Callback function called when property "useColliders" is updated.
+     *
+     * @private
+     */
+    _onSetUseColliders() {
+        if (!this.useColliders) {
+            this._destroyCollisionShape();
         }
     }
 
-    get size() {
-        return this._size;
+    /**
+     * Callback function called when property "shape" is updated.
+     *
+     * @private
+     */
+    _onSetShape() {
+        if (this._collisionShape) {
+            this._recreateCollisionShape();
+        }
     }
 
-    onEnable() {
-        this._checkState();
+    /**
+     * Callback function called when property "halfExtents" is updated.
+     *
+     * @private
+     */
+    _onSetHalfExtents() {
+        if (this.shape === 'box' && this._collisionShape) {
+            this._recreateCollisionShape();
+        }
     }
 
-    onDisable() {
-        this._checkState();
+    /**
+     * Callback function called when property "radius" is updated.
+     *
+     * @private
+     */
+    _onSetRadius() {
+        if (this.shape === 'sphere' && this._collisionShape) {
+            this._recreateCollisionShape();
+        }
     }
 
-    _onSetEnabled(prop, old, value) {
-        this._checkState();
+    /**
+     * Destroy physical shape.
+     *
+     * @private
+     */
+    _destroyCollisionShape() {
+        if (typeof Ammo !== 'undefined') {
+            if (this._collisionShape) {
+                Ammo.destroy(this._collisionShape);
+                this._collisionShape = null;
+            }
+        }
     }
 
-    _checkState() {
-        const state = this.enabled && this.entity.enabled;
-        if (state === this._oldState)
+    /**
+     * Recreate physical shape.
+     *
+     * @private
+     */
+    _recreateCollisionShape() {
+        if (typeof Ammo !== 'undefined' && this.useColliders) {
+            this._destroyCollisionShape();
+
+            const halfExtents = this.halfExtents;
+            if (this.shape === 'box' && (halfExtents.x !== 0 || halfExtents.y !== 0 || halfExtents.z !== 0)) {
+                const ammoVec3 = new Ammo.btVector3(halfExtents.x, halfExtents.y, halfExtents.z);
+                this._collisionShape = new Ammo.btBoxShape(ammoVec3);
+                Ammo.destroy(ammoVec3);
+            } else if (this.shape === 'sphere' && this.radius > 0) {
+                this._collisionShape = new Ammo.btSphereShape(this.radius);
+            }
+        }
+    }
+
+    /**
+     * Check if a point is within the zone.
+     *
+     * @param {Vec3} point - The point to look for.
+     * @param {Vec3} position - The position of this entity.
+     * @param {import('../../../core/math/quat').Quat} rotation - The rotation of this entity.
+     * @param {Mat4} matrix - The matrix for box calculations.
+     * @returns {boolean} Whether the point is within the zone.
+     * @private
+     */
+    _isPointInZone(point, position = this.entity.getPosition(), rotation = this.entity.getRotation(), matrix = undefined) {
+        if (this.shape === 'box') {
+            if (!matrix) {
+                matrix = _matrix;
+                matrix.setTRS(position, rotation, Vec3.ONE);
+                matrix.invert();
+            }
+
+            const localPoint = matrix.transformPoint(point);
+            const halfExtents = this.halfExtents;
+            if (Math.abs(localPoint.x) <= halfExtents.x && Math.abs(localPoint.y) <= halfExtents.y && Math.abs(localPoint.z) <= halfExtents.z) {
+                return true;
+            }
+        } else if (point.distance(position) <= this.radius) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a point is within the zone.
+     *
+     * @param {Vec3} point - The point to look for.
+     * @returns {boolean} Whether the point is within the zone.
+     */
+    isPointInZone(point) {
+        return this._isPointInZone(point);
+    }
+
+    /**
+     * Refresh the list of entities within the zone.
+     *
+     * @ignore
+     */
+    checkEntities() {
+        if (!this.entity.enabled || !this.enabled) {
             return;
+        }
 
-        this._oldState = state;
+        const position = this.entity.getPosition();
+        const rotation = this.entity.getRotation();
 
-        this.fire('enable');
-        this.fire('state', this.enabled);
+        _matrix.setTRS(position, rotation, Vec3.ONE);
+        _matrix.invert();
+
+        let pendingCollider;
+        const entities = Object.values(this.system.app._entityIndex);
+
+        // Check entities as per position
+        for (let i = 0, l = entities.length; i < l; i++) {
+            const entity = entities[i];
+
+            // Don't check for self.
+            if (entity === this.entity) {
+                continue;
+            }
+
+            const index = this.entities.indexOf(entity);
+
+            if (!entity.enabled) {
+                if (index !== -1) {
+                    this.entities.splice(index, 1);
+                }
+
+                continue;
+            }
+
+            if (this._isPointInZone(entity.getPosition(), position, rotation, _matrix)) {
+                if (index === -1) {
+                    entity.fire('zoneEnter', this);
+                    this.fire('entityEnter', entity);
+                    this.entities.push(entity);
+                }
+            } else if (this.useColliders && entity.collision && entity.collision.enabled && entity.collision.zoneCheck) {
+                if (!pendingCollider) {
+                    pendingCollider = [];
+                }
+
+                pendingCollider.push(entity);
+            } else if (index !== -1) {
+                entity.fire('zoneLeave', this);
+                this.fire('entityleave', entity);
+                this.entities.splice(index, 1);
+            }
+        }
+
+        // Check entities as per colliders
+        if (this.useColliders && pendingCollider && pendingCollider.length && this.system.app.systems.rigidbody) {
+            if (!this._collisionShape) {
+                this._recreateCollisionShape();
+            }
+
+            if (this._collisionShape) {
+                if (!this._halfExtentsLast.equals(this.halfExtents)) {
+                    this.fire('set_halfExtents', this._halfExtentsLast, this.halfExtents);
+                    this._halfExtentsLast.copy(this.halfExtents);
+                }
+
+                const collidingEntities = this.system.app.systems.rigidbody._shapeTestAll(this._collisionShape, position, rotation, false);
+
+                for (let i = 0, l = pendingCollider.length; i < l; i++) {
+                    const entity = pendingCollider[i];
+                    const collidingIndex = collidingEntities.findIndex(r => r.entity === entity);
+                    const inZoneIndex = this.entities.indexOf(entity);
+
+                    if (collidingIndex !== -1 && inZoneIndex !== -1) {
+                        // Entity was already in zone.
+                        continue;
+                    } else if (collidingIndex !== -1) {
+                        // Entity entered zone.
+                        entity.fire('zoneEnter', this);
+                        this.fire('entityEnter', entity);
+                        this.entities.push(entity);
+                    } else if (inZoneIndex !== -1) {
+                        // Entity left zone.
+                        entity.fire('zoneLeave', this);
+                        this.fire('entityLeave', entity);
+                        this.entities.splice(inZoneIndex, 1);
+                    }
+                }
+            }
+        } else if (this._collisionShape) {
+            this._destroyCollisionShape();
+        }
     }
 
+    /**
+     * Function called when the component is getting enabled.
+     *
+     * @ignore
+     */
+    onEnable() {
+        this.system.addZone(this);
+        this._toggleLifecycleListeners('on');
+        this.checkEntities();
+    }
+
+    /**
+     * Function called when the component is getting disabled.
+     *
+     * @ignore
+     */
+    onDisable() {
+        this.system.removeZone(this);
+        this._destroyCollisionShape();
+        this._toggleLifecycleListeners('off');
+
+        for (let i = 0, l = this.entities.length; i < l; i++) {
+            this.entities[i].fire('zoneLeave', this);
+        }
+
+        this.entities.length = 0;
+    }
+
+    /**
+     * Callback function called when component is getting removed.
+     *
+     * @ignore
+     */
     _onBeforeRemove() {
-        this.fire('remove');
+        this.onDisable();
     }
 }
 

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,5 +1,5 @@
 import { Vec3 } from '../../../core/math/vec3.js';
-
+// Magnopus Patched
 class ZoneComponentData {
     constructor() {
         this.enabled = true;

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,5 +1,5 @@
 import { Vec3 } from '../../../core/math/vec3.js';
-// Magnopus Patched
+
 class ZoneComponentData {
     constructor() {
         this.enabled = true;

--- a/src/framework/components/zone/data.js
+++ b/src/framework/components/zone/data.js
@@ -1,6 +1,12 @@
+import { Vec3 } from '../../../core/math/vec3.js';
+
 class ZoneComponentData {
     constructor() {
         this.enabled = true;
+        this.type = 'box';
+        this.halfExtents = new Vec3(0.5, 0.5, 0.5);
+        this.radius = 0.5;
+        this.useColliders = false;
     }
 }
 

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -7,7 +7,7 @@ import { ZoneComponent } from './component.js';
 import { ZoneComponentData } from './data.js';
 
 const _schema = ['enabled', 'shape', 'halfExtents', 'radius', 'useColliders'];
-
+// Magnopus Patched
 /**
  * Creates and manages {@link ZoneComponent} instances.
  *

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -7,7 +7,7 @@ import { ZoneComponent } from './component.js';
 import { ZoneComponentData } from './data.js';
 
 const _schema = ['enabled', 'shape', 'halfExtents', 'radius', 'useColliders'];
-// Magnopus Patched
+
 /**
  * Creates and manages {@link ZoneComponent} instances.
  *

--- a/src/framework/components/zone/system.js
+++ b/src/framework/components/zone/system.js
@@ -6,56 +6,167 @@ import { ComponentSystem } from '../system.js';
 import { ZoneComponent } from './component.js';
 import { ZoneComponentData } from './data.js';
 
-const _schema = ['enabled'];
+const _schema = ['enabled', 'shape', 'halfExtents', 'radius', 'useColliders'];
 
 /**
  * Creates and manages {@link ZoneComponent} instances.
  *
  * @augments ComponentSystem
- * @ignore
  */
 class ZoneComponentSystem extends ComponentSystem {
     /**
-     * Create a new ZoneComponentSystem.
+     * Holds all the active zone components.
      *
-     * @param {import('../../app-base.js').AppBase} app - The application.
+     * @type {ZoneComponent[]}
+     */
+    zones = [];
+
+    /**
+     * Create a new ZoneComponentSystem instance.
+     *
+     * @param {import('../../app-base.js').AppBase} app - The Application.
      * @hideconstructor
      */
     constructor(app) {
         super(app);
 
+        // Defining system name.
         this.id = 'zone';
 
+        // Defining different types used by system.
         this.ComponentType = ZoneComponent;
         this.DataType = ZoneComponentData;
 
+        // Define data schema.
         this.schema = _schema;
 
-        this.on('beforeremove', this._onBeforeRemove, this);
+        // Own listeners.
+        this.on('add', this.onAdd, this);
+        this.on('beforeremove', this.onBeforeRemove, this);
+        this.app.systems.on('update', this.onUpdate, this);
     }
 
+    /**
+     * Initialize component with default data.
+     *
+     * @param {*} component - The component to initialize.
+     * @param {*} data - The data to initialize the component with.
+     * @param {*} properties - .
+     * @ignore
+     */
     initializeComponentData(component, data, properties) {
         component.enabled = data.hasOwnProperty('enabled') ? !!data.enabled : true;
 
-        if (data.size) {
-            if (data.size instanceof Vec3) {
-                component.size.copy(data.size);
-            } else if (data.size instanceof Array && data.size.length >= 3) {
-                component.size.set(data.size[0], data.size[1], data.size[2]);
+        if (data.shape) {
+            component.shape = data.shape;
+        }
+
+        if (!isNaN(data.radius)) {
+            component.radius = data.radius;
+        }
+
+        if (data.hasOwnProperty('useColliders')) {
+            component.useColliders = !!data.useColliders;
+        }
+
+        if (data.halfExtents) {
+            if (data.halfExtents instanceof Vec3) {
+                component.halfExtents.copy(data.halfExtents);
+            } else if (data.halfExtents instanceof Array && data.halfExtents.length >= 3) {
+                component.halfExtents.set(data.halfExtents[0], data.halfExtents[1], data.halfExtents[2]);
             }
+
+            component._halfExtentsLast.copy(component.halfExtents);
         }
     }
 
+    /**
+     * Function to clone component from one entity to another.
+     *
+     * @param {import('../../entity').Entity} entity - The entity to get the component from.
+     * @param {import('../../entity').Entity} clone - The entity to assign the clonned component to.
+     * @returns {Component} - Result component from clonning.
+     * @ignore
+     */
     cloneComponent(entity, clone) {
-        const data = {
-            size: entity.zone.size
-        };
-
-        return this.addComponent(clone, data);
+        const c = entity.zone;
+        return this.addComponent(clone, {
+            size: c.size,
+            shape: c.shape,
+            halfExtents: c.halfExtents,
+            radius: c.radius
+        });
     }
 
-    _onBeforeRemove(entity, component) {
-        component._onBeforeRemove();
+    /**
+     * Callback function to call when a component is getting removed.
+     *
+     * @param {import('../../entity').Entity} entity - Entity the component is removed from.
+     * @param {ZoneComponent} component - Component getting removed.
+     * @private
+     */
+    onAdd(entity, component) {
+        if (entity.enabled && component.enabled) {
+            component.onEnable();
+        }
+    }
+
+    /**
+     * Callback function to call when a component is getting removed.
+     *
+     * @param {import('../../entity').Entity} entity - Entity the component is removed from.
+     * @param {ZoneComponent} component - Component getting removed.
+     * @private
+     */
+    onBeforeRemove(entity, component) {
+        component.onDisable();
+    }
+
+    /**
+     * Callback function to call on every systems update.
+     *
+     * @param {number} dt - Time since last update in seconds.
+     * @private
+     */
+    onUpdate(dt) {
+        const zones = this.zones;
+        for (let i = 0, l = zones.length; i < l; i++) {
+            zones[i].checkEntities();
+        }
+    }
+
+    /**
+     * Adds a new zone to update.
+     *
+     * @param {ZoneComponent} zone - The zone to add.
+     * @ignore
+     */
+    addZone(zone) {
+        if (this.zones.indexOf(zone) === -1) {
+            this.zones.push(zone);
+        }
+    }
+
+    /**
+     * Remove a zone from updates.
+     *
+     * @param {ZoneComponent} zone - The zone to remove.
+     * @ignore
+     */
+    removeZone(zone) {
+        const index = this.zones.indexOf(zone);
+        if (index >= 0) {
+            this.zones.splice(index, 1);
+        }
+    }
+
+    /**
+     * Destroy the Zone Component System.
+     */
+    destroy() {
+        super.destroy();
+
+        this.app.systems.off('update', this.onUpdate, this);
     }
 }
 

--- a/src/framework/entity.js
+++ b/src/framework/entity.js
@@ -188,6 +188,14 @@ class Entity extends GraphNode {
     sprite;
 
     /**
+     * Gets the {@link ZoneComponent} attached to this entity.
+     *
+     * @type {import('./components/zone/component.js').ZoneComponent|undefined}
+     * @readonly
+     */
+    zone;
+
+    /**
      * Component storage.
      *
      * @type {Object<string, import('./components/component.js').Component>}
@@ -265,6 +273,37 @@ class Entity extends GraphNode {
     }
 
     /**
+     * Fired when the entity enters a zone.
+     *
+     * @event Entity#zoneEnter
+     * @param {import('./components/zone/component').ZoneComponent} zone - The zone that entity entered.
+     * @example
+     * entity.on('zoneEnter', function (zone) {
+     *     // entity entered a zone
+     * });
+     */
+
+    /**
+     * Fired when the entity leaves a zone.
+     *
+     * @event Entity#zoneLeave
+     * @param {import('./components/zone/component').ZoneComponent} zone - The zone that entity left.
+     * @example
+     * entity.on('zoneLeave', function (entity) {
+     *     // entity left a zone
+     * });
+     */
+
+    /**
+     * List of all zones this entity is currently within.
+     *
+     * @type {import('./components/zone/component').ZoneComponent[]}
+     */
+    get zones() {
+        return this._app.systems.zone.zones.filter(z => z.entities.indexOf(this) !== -1);
+    }
+
+    /**
      * Create a new component and add it to the entity. Use this to add functionality to the entity
      * like rendering a model, playing sounds and so on.
      *
@@ -290,6 +329,7 @@ class Entity extends GraphNode {
      * - "scrollview" - see {@link ScrollViewComponent}
      * - "sound" - see {@link SoundComponent}
      * - "sprite" - see {@link SpriteComponent}
+     * - "zone" - see {@link ZoneComponent}
      *
      * @param {object} [data] - The initialization data for the specific component type. Refer to
      * each specific component's API reference page for details on valid values for this parameter.

--- a/src/index.js
+++ b/src/index.js
@@ -204,7 +204,7 @@ export { RenderComponent } from './framework/components/render/component.js';
 export { RenderComponentSystem } from './framework/components/render/system.js';
 export * from './framework/components/rigid-body/constants.js';
 export { RigidBodyComponent } from './framework/components/rigid-body/component.js';
-export { RigidBodyComponentSystem, ContactPoint, ContactResult, RaycastResult, SingleContactResult } from './framework/components/rigid-body/system.js';
+export { RigidBodyComponentSystem, ContactPoint, ContactResult, HitResult, SingleContactResult } from './framework/components/rigid-body/system.js';
 export { SceneRegistry } from './framework/scene-registry.js';
 export { SceneRegistryItem } from './framework/scene-registry-item.js';
 export * from './framework/components/screen/constants.js';

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -349,7 +349,8 @@ class StandardMaterialOptionsBuilder {
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
         options.litOptions.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0 || scene.physicalUnits);
-        options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
+        // magnopus patched, allow cubemap rotation on all cubemaps
+        options.litOptions.useCubeMapRotation = scene._skyboxRotationShaderInclude && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 
     _updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -1,4 +1,3 @@
-import { Quat } from '../../core/math/quat.js';
 import {
     PIXELFORMAT_DXT5, PIXELFORMAT_RGBA8, TEXTURETYPE_SWIZZLEGGGR
 } from '../../platform/graphics/constants.js';
@@ -12,7 +11,7 @@ import {
     SHADERDEF_DIRLM, SHADERDEF_INSTANCING, SHADERDEF_LM, SHADERDEF_MORPH_POSITION, SHADERDEF_MORPH_NORMAL, SHADERDEF_NOSHADOW, SHADERDEF_MORPH_TEXTURE_BASED,
     SHADERDEF_SCREENSPACE, SHADERDEF_SKIN, SHADERDEF_TANGENTS, SHADERDEF_UV0, SHADERDEF_UV1, SHADERDEF_VCOLOR, SHADERDEF_LMAMBIENT,
     TONEMAP_LINEAR,
-    SPECULAR_PHONG,
+    SPECULAR_PHONG
 } from '../constants.js';
 import { _matTex2D } from '../shader-lib/programs/standard.js';
 
@@ -99,16 +98,10 @@ class StandardMaterialOptionsBuilder {
     _updateUVOptions(options, stdMat, objDefs, minimalOptions) {
         let hasUv0 = false;
         let hasUv1 = false;
-        let hasUv2 = false;
-        let hasUv3 = false;
-        let hasUv4 = false;
         let hasVcolor = false;
         if (objDefs) {
             hasUv0 = (objDefs & SHADERDEF_UV0) !== 0;
             hasUv1 = (objDefs & SHADERDEF_UV1) !== 0;
-            hasUv2 = hasUv1;
-            hasUv3 = hasUv1;
-            hasUv4 = hasUv1;
             hasVcolor = (objDefs & SHADERDEF_VCOLOR) !== 0;
         }
 
@@ -308,15 +301,12 @@ class StandardMaterialOptionsBuilder {
 
         // source of environment reflections is as follows:
         if (stdMat.envAtlas && stdMat.cubeMap && !isPhong) {
-            // magnopus patched, force envAtlas source due to missing reflections
-            options.litOptions.reflectionSource = 'envAtlas';
+            options.litOptions.reflectionSource = 'envAtlasHQ';
             options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
             options.litOptions.reflectionCubemapEncoding = stdMat.cubeMap.encoding;
         } else if (stdMat.envAtlas && !isPhong) {
             options.litOptions.reflectionSource = 'envAtlas';
             options.litOptions.reflectionEncoding = stdMat.envAtlas.encoding;
-            // Magnopus Patched
-            usingSceneEnv = true;
         } else if (stdMat.cubeMap) {
             options.litOptions.reflectionSource = 'cubeMap';
             options.litOptions.reflectionEncoding = stdMat.cubeMap.encoding;
@@ -324,8 +314,7 @@ class StandardMaterialOptionsBuilder {
             options.litOptions.reflectionSource = 'sphereMap';
             options.litOptions.reflectionEncoding = stdMat.sphereMap.encoding;
         } else if (stdMat.useSkybox && scene.envAtlas && scene.skybox && !isPhong) {
-            // magnopus patched, force envAtlas source due to missing reflections
-            options.litOptions.reflectionSource = 'envAtlas';
+            options.litOptions.reflectionSource = 'envAtlasHQ';
             options.litOptions.reflectionEncoding = scene.envAtlas.encoding;
             options.litOptions.reflectionCubemapEncoding = scene.skybox.encoding;
             usingSceneEnv = true;

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -348,7 +348,7 @@ class StandardMaterialOptionsBuilder {
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
         options.litOptions.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0 || scene.physicalUnits);
-        options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
+        options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude && scene.skyboxRotation;
     }
 
     _updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList) {

--- a/src/scene/materials/standard-material-options-builder.js
+++ b/src/scene/materials/standard-material-options-builder.js
@@ -1,3 +1,4 @@
+import { Quat } from '../../core/math/quat.js';
 import {
     PIXELFORMAT_DXT5, PIXELFORMAT_RGBA8, TEXTURETYPE_SWIZZLEGGGR
 } from '../../platform/graphics/constants.js';
@@ -348,7 +349,7 @@ class StandardMaterialOptionsBuilder {
 
         // TODO: add a test for if non skybox cubemaps have rotation (when this is supported) - for now assume no non-skybox cubemap rotation
         options.litOptions.skyboxIntensity = usingSceneEnv && (scene.skyboxIntensity !== 1 || scene.skyboxLuminance !== 0 || scene.physicalUnits);
-        options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude && scene.skyboxRotation;
+        options.litOptions.useCubeMapRotation = usingSceneEnv && scene._skyboxRotationShaderInclude && scene.skyboxRotation && !scene.skyboxRotation.equals(Quat.IDENTITY);
     }
 
     _updateLightOptions(options, scene, stdMat, objDefs, sortedLights, staticLightList) {

--- a/src/scene/materials/standard-material.js
+++ b/src/scene/materials/standard-material.js
@@ -840,7 +840,7 @@ class StandardMaterial extends Material {
         if (!hasLocalEnvOverride && this.useSkybox) {
             if (scene.envAtlas && scene.skybox && !isPhong) {
                 this._setParameter('texture_envAtlas', scene.envAtlas);
-                this._setParameter('texture_cubeMap', scene.envAtlas);
+                this._setParameter('texture_cubeMap', scene.skybox);
             } else if (scene.envAtlas && !isPhong) {
                 this._setParameter('texture_envAtlas', scene.envAtlas);
             } else if (scene.skybox) {

--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -3,6 +3,7 @@ import {
     SEMANTIC_BLENDINDICES, SEMANTIC_BLENDWEIGHT, SEMANTIC_COLOR, SEMANTIC_NORMAL, SEMANTIC_POSITION, SEMANTIC_TANGENT,
     SEMANTIC_TEXCOORD0, SEMANTIC_TEXCOORD1,
     SHADERTAG_MATERIAL,
+    // Magnopus patched
     SEMANTIC_TEXCOORD2,
     SEMANTIC_TEXCOORD3,
     SEMANTIC_TEXCOORD4,
@@ -36,6 +37,7 @@ const builtinAttributes = {
     vertex_tangent: SEMANTIC_TANGENT,
     vertex_texCoord0: SEMANTIC_TEXCOORD0,
     vertex_texCoord1: SEMANTIC_TEXCOORD1,
+    // Magnopus patched
     vertex_texCoord2: SEMANTIC_TEXCOORD2,
     vertex_texCoord3: SEMANTIC_TEXCOORD3,
     vertex_texCoord4: SEMANTIC_TEXCOORD4,
@@ -249,8 +251,8 @@ class LitShader {
                 codeBody += "   vObjectSpaceUpW = normalize(dNormalMatrix * vec3(0, 1, 0));\n";
             }
         }
-
-        const maxUvSets = 8;
+        // Magnopus patched
+        const maxUvSets = 5;
 
         for (let i = 0; i < maxUvSets; i++) {
             if (useUv[i]) {


### PR DESCRIPTION
See https://github.com/playcanvas/engine/pull/5123 for details
ZoneComponent, required for tracking objects inside of volumes used by reflection probes etc

1. Adds support for ray casting shapes
2. Adds full support for the playcanvas 'zone' component which allows areas to be specified to trigger changes on enter leave and track objects inside of it


https://github.com/magnopus/playcanvas-engine/assets/100127317/ff8d7fbd-9cb1-49ee-bbe4-d30e888e7180

