### PR TITLE
[OW-1466] fix: Deployment now updates the files in oly-web-client more completely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ typedocs
 stats.html
 .npmrc
 examples/.npmrc
+.yarn
+.yarnrc.yml
+yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "playcanvas",
-  "version": "1.65.0-dev",
+  "version": "1.65.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "playcanvas",
-      "version": "1.65.0-dev",
+      "version": "1.65.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.22.9",
@@ -19,7 +19,7 @@
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-strip": "^3.0.2",
         "@rollup/plugin-terser": "^0.4.3",
-        "@rollup/pluginutils": "^5.0.2",
+        "@rollup/pluginutils": "^5.0.4",
         "@webgpu/types": "^0.1.34",
         "c8": "^8.0.0",
         "chai": "^4.3.7",
@@ -32,7 +32,7 @@
         "karma-mocha": "2.0.1",
         "karma-spec-reporter": "^0.0.36",
         "mocha": "^10.2.0",
-        "rollup": "^3.26.3",
+        "rollup": "^3.29.0",
         "rollup-plugin-dts": "^5.3.0",
         "rollup-plugin-jscc": "2.0.0",
         "rollup-plugin-visualizer": "^5.9.2",
@@ -2170,9 +2170,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
+      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -7126,9 +7126,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
-      "integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.0.tgz",
+      "integrity": "sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs",
+    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cp -rf package.json ../oly-web-client/libs/overrides/playcanvas/scripts",
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && rm -rf ../oly-web-client/libs/overrides/playcanvas/scripts && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cat package.json | sed -e 's?\"module\": \"build/playcanvas.mjs/index.js\"?\"module\": \"build/playcanvas.mjs\"?' > ../oly-web-client/libs/overrides/playcanvas/package.json",
+    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && cp LICENSE ../oly-web-client/libs/overrides/playcanvas && rm -rf ../oly-web-client/libs/overrides/playcanvas/scripts && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cat package.json | sed -e 's?\"module\": \"build/playcanvas.mjs/index.js\"?\"module\": \"build/playcanvas.mjs\"?' > ../oly-web-client/libs/overrides/playcanvas/package.json",
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cp -rf package.json ../oly-web-client/libs/overrides/playcanvas/scripts",
+    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && rm -rf ../oly-web-client/libs/overrides/playcanvas/scripts && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cp -rf package.json ../oly-web-client/libs/overrides/playcanvas",
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playcanvas",
-  "version": "1.65.3",
+  "version": "1.65.3-OW1466",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "PlayCanvas WebGL game engine",
@@ -99,7 +99,7 @@
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-strip": "^3.0.2",
     "@rollup/plugin-terser": "^0.4.3",
-    "@rollup/pluginutils": "^5.0.2",
+    "@rollup/pluginutils": "^5.0.4",
     "@webgpu/types": "^0.1.34",
     "c8": "^8.0.0",
     "chai": "^4.3.7",
@@ -125,7 +125,7 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && rm -rf ../oly-web-client/libs/overrides/playcanvas/scripts && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cp -rf package.json ../oly-web-client/libs/overrides/playcanvas",
+    "deploy": "npm run build:release && npm run build:types && yarn rollup -i build/playcanvas.mjs/index.js -o build/playcanvas.rel.mjs && cp -rf build/playcanvas.d.ts ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.d.ts && cp -rf build/playcanvas.rel.mjs ../oly-web-client/libs/overrides/playcanvas/build/playcanvas.mjs && rm -rf ../oly-web-client/libs/overrides/playcanvas/scripts && cp -rf scripts ../oly-web-client/libs/overrides/playcanvas && cat package.json | sed -e 's?\"module\": \"build/playcanvas.mjs/index.js\"?\"module\": \"build/playcanvas.mjs\"?' > ../oly-web-client/libs/overrides/playcanvas/package.json",
     "build:release": "rollup -c --environment target:release",
     "build:debug": "rollup -c --environment target:debug",
     "build:dts": "tsc src/index.js --outDir types --allowJs --declaration --emitDeclarationOnly",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "^0.0.36",
     "mocha": "^10.2.0",
-    "rollup": "^3.26.3",
+    "rollup": "^3.29.0",
     "rollup-plugin-dts": "^5.3.0",
     "rollup-plugin-jscc": "2.0.0",
     "rollup-plugin-visualizer": "^5.9.2",


### PR DESCRIPTION
[OW-1466] fix: Deployment now updates the files in oly-web-client more completely

- The package.json file is copied across, fixing the module filename to 'build/playcanvas.mjs'
- The scripts folder is updated


[OW-1466]: https://magnopus.atlassian.net/browse/OW-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ