### PR TITLE
[OW-1482] fix: support box projected reflection, fix rotation

### DIFF
--- a/src/framework/components/zone/component.js
+++ b/src/framework/components/zone/component.js
@@ -292,7 +292,23 @@ class ZoneComponent extends Component {
                 continue;
             }
 
-            if (this._isPointInZone(entity.getPosition(), position, rotation, _matrix)) {
+            // Magnopus Patched, add support for zones over mesh instances
+            if (entity.render) {
+                const inZone = entity.render.meshInstances.some((mi) => {
+                    return this._isPointInZone(mi.aabb.center, position, rotation, _matrix);
+                });
+                if (inZone) {
+                    if (index === -1) {
+                        this.entities.push(entity);
+                        entity.fire('zoneEnter', this);
+                        this.fire('entityEnter', entity);
+                    }
+                } else if (index !== -1) {
+                    this.entities.splice(index, 1);
+                    entity.fire('zoneLeave', this);
+                    this.fire('entityleave', entity);
+                }
+            } else if (this._isPointInZone(entity.getPosition(), position, rotation, _matrix)) {
                 if (index === -1) {
                     this.entities.push(entity);
                     entity.fire('zoneEnter', this);

--- a/src/scene/shader-lib/chunks/lit/frag/cubeMapProjectBox.js
+++ b/src/scene/shader-lib/chunks/lit/frag/cubeMapProjectBox.js
@@ -3,7 +3,8 @@ uniform vec3 envBoxMin;
 uniform vec3 envBoxMax;
 
 vec3 cubeMapProject(vec3 nrdir) {
-    nrdir = cubeMapRotate(nrdir);
+    // magnopus patched
+    // nrdir = cubeMapRotate(nrdir);
 
     vec3 rbmax = (envBoxMax - vPositionW) / nrdir;
     vec3 rbmin = (envBoxMin - vPositionW) / nrdir;
@@ -17,6 +18,7 @@ vec3 cubeMapProject(vec3 nrdir) {
 
     vec3 posonbox = vPositionW + nrdir * fa;
     vec3 envBoxPos = (envBoxMin + envBoxMax) * 0.5;
-    return normalize(posonbox - envBoxPos);
+    // magnopus patched
+    return cubeMapRotate(normalize(posonbox - envBoxPos));
 }
 `;


### PR DESCRIPTION
[OW-1482] fix: support box projected reflection, fix rotation

- Allow zone component to fire when a meshInstance of an entity is within a zone
- Patch cubemap rotation to support box projections by disabling the box rotating and instead only rotating the texture

[OW-1482]: https://magnopus.atlassian.net/browse/OW-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ