### PR TITLE
[OB-2997] fix: Issue rendering depth buffer for render targets with single pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playcanvas",
-  "version": "1.65.3-OW1482",
+  "version": "1.65.3-OB2997",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "PlayCanvas WebGL game engine",

--- a/src/scene/frame-graph.js
+++ b/src/scene/frame-graph.js
@@ -58,6 +58,13 @@ class FrameGraph {
                         prevPass.depthStencilOps.storeStencil = true;
                     }
                 }
+                // Magnopus patched
+                // pending the outcome from https://github.com/playcanvas/engine/issues/5823 this change 
+                // sets the store depth flag when a pass is requesting depth and there isn't a previous pass 
+                // and there is a valid render target 
+                else if (renderTarget?.depth) {
+                  renderPass.depthStencilOps.storeDepth = true;
+                }
 
                 // add the pass to the map
                 renderTargetMap.set(renderTarget, renderPass);


### PR DESCRIPTION
[OB-2997] fix: Issue rendering depth buffer for render targets with single pass

- The code that configures the flag to render depth was not dealing with the case where you have a render target that has requested rendering depth and is rendering that information to a specific texture. 
- This change detects render targets that are requesting depth, and there isn't a previous pass on which the store depth flag would normally be set. In this case the store depth flag in set on the current path

[OB-2997]: https://magnopus.atlassian.net/browse/OB-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ