### PR TITLE
[OB-3070] fix: Performance regression for reflection probes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playcanvas",
-  "version": "1.65.3-OB2997",
+  "version": "1.65.3-OB3070",
   "author": "PlayCanvas <support@playcanvas.com>",
   "homepage": "https://playcanvas.com",
   "description": "PlayCanvas WebGL game engine",

--- a/src/scene/graph-node.js
+++ b/src/scene/graph-node.js
@@ -6,6 +6,7 @@ import { Mat3 } from '../core/math/mat3.js';
 import { Mat4 } from '../core/math/mat4.js';
 import { Quat } from '../core/math/quat.js';
 import { Vec3 } from '../core/math/vec3.js';
+import { getApplication } from '../framework/globals.js';
 
 const scaleCompensatePosTransform = new Mat4();
 const scaleCompensatePos = new Vec3();
@@ -254,7 +255,8 @@ class GraphNode extends EventHandler {
      */
     constructor(name = 'Untitled', app) {
         super();
-        this._appRef = app;
+        // Magnopus Patched OB-3070
+        this._appRef = app ?? getApplication();
         this.name = name;
     }
 


### PR DESCRIPTION
[OB-3070] fix: Performance regression for reflection probes

- ensure _appRef is set when creating GraphNodes so that _dirtyZoneEntities is correctly populated
- This ensures that dirty zone components are cleaned up as expected and not permanently "dirty"


[OB-3070]: https://magnopus.atlassian.net/browse/OB-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ