### PR TITLE
fix for flippped normals when camera has a renderTarget with flipY set

### DIFF
--- a/src/scene/shader-lib/programs/lit-shader.js
+++ b/src/scene/shader-lib/programs/lit-shader.js
@@ -1028,9 +1028,11 @@ class LitShader {
                 backend.append('    addReflection(dReflDirW, litArgs_gloss);');
 
                 if (options.fresnelModel > 0) {
+                    // magnopus patched
+                    decl.append('uniform float projectionFlipY;');
                     backend.append(`    dReflection.rgb *= 
                         getFresnel(
-                            dot(dViewDirW, litArgs_worldNormal), 
+                            dot(dViewDirW, litArgs_worldNormal * projectionFlipY), 
                             litArgs_gloss, 
                             litArgs_specularity
                         #if defined(LIT_IRIDESCENCE)


### PR DESCRIPTION
Fixes #

I confirm I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://docs.google.com/a/playcanvas.com/forms/d/1Ih69zQfJG-QDLIEpHr6CsaAs6fPORNOVnMv5nuo0cjk/viewform).
