### PR TITLE
[OB-4477] fix: update cameraFrame

### DIFF
--- a/src/extras/render-passes/camera-frame.js
+++ b/src/extras/render-passes/camera-frame.js
@@ -321,7 +321,10 @@ class CameraFrame {
 
         // handle layer changes on the camera - render passes need to be update to reflect the changes
         this.cameraLayersChanged = cameraComponent.on('set:layers', () => {
-            if (this.renderPassCamera) this.renderPassCamera.layersDirty = true;
+            if (this.renderPassCamera) {
+                // magnopus patched https://magnopus.atlassian.net/browse/OB-4477
+                this.update();
+            }
         });
     }
 

--- a/src/scene/graphics/prefilter-cubemap.js
+++ b/src/scene/graphics/prefilter-cubemap.js
@@ -56,10 +56,10 @@ function texelCoordSolidAngle(u, v, size) {
  * @async
  * @param {import('../../platform/graphics/graphics-device.js').GraphicsDevice} device - The graphics device
  * @param {import('../../platform/graphics/texture.js').Texture} source - The source cubemap texture (must be RGBA8 format and synced to CPU)
- * @param {boolean} [dontFlipX=false] - If true, doesn't flip the X direction when calculating coefficients
+ * @param {boolean} [dontFlipX] - If true, doesn't flip the X direction when calculating coefficients
  * @returns {Promise<Float32Array|null>} A Float32Array containing 27 coefficients (9 spherical harmonics × 3 color channels),
- *          or null if the input cubemap doesn't meet requirements
- * 
+ * or null if the input cubemap doesn't meet requirements
+ *
  * @example
  * // Get SH coefficients from a cubemap
  * const shCoefficients = await shFromCubemap(device, cubemapTexture);


### PR DESCRIPTION
[OB-4477] fix: update cameraFrame
- call cameraFrame.update instead of cameraFrameRenderPass.update which resets rendering settings to default