### PR TITLE
Add withCredentials to send cookies with loadImageBitmap

### DIFF
--- a/src/framework/parsers/texture/img.js
+++ b/src/framework/parsers/texture/img.js
@@ -137,7 +137,9 @@ class ImgParser extends TextureParser {
             responseType: 'blob',
             retry: this.maxRetries > 0,
             maxRetries: this.maxRetries,
-            progress: asset
+            progress: asset,
+            // Magnopus patched - add withCredentials option
+            withCredentials: crossOrigin === 'use-credentials'
         };
         http.get(url, options, (err, blob) => {
             if (err) {


### PR DESCRIPTION
## Description

Set the withCredentials property for loadImageBitmap so it can change this based on the data rather than only using a default. Needed for loading images behind our asset security in the renderer.

Fixes #

## Checklist
- [ ] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [ ] My code follows the project's coding standards
- [ ] This PR focuses on a single change
