### PR TITLE
[OB-5588] fix: Add shader support for LOD debug visualization in WebGPU

### DIFF
--- a/src/scene/shader-lib/glsl/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/glsl/chunks/lit/frag/debug-output.js
@@ -3,7 +3,7 @@ export default /* glsl */`
 gl_FragColor = vec4(gammaCorrectOutput(dAlbedo), 1.0);
 #endif
 
-// magnopus patched
+// magnopus patched - start
 #ifdef LOD_PASS
 if (lod_level == 0) {
   gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
@@ -15,6 +15,7 @@ if (lod_level == 0) {
   gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0);
 }
 #endif
+// magnopus patched - end
 
 #ifdef DEBUG_UV0_PASS
 gl_FragColor = vec4(litArgs_albedo , 1.0);

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/base.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/base.js
@@ -2,6 +2,12 @@ export default /* wgsl */`
 uniform view_position: vec3f;
 
 // magnopus patched
+#ifdef LOD_PASS
+uniform lod_level: i32;
+#endif
+// end magnopus patched
+
+// magnopus patched
 #ifdef MAG_STEREO_TEXTURE
 // Set by the engine but not declared anywhere else
 uniform view_index: f32;

--- a/src/scene/shader-lib/wgsl/chunks/lit/frag/debug-output.js
+++ b/src/scene/shader-lib/wgsl/chunks/lit/frag/debug-output.js
@@ -3,6 +3,20 @@ export default /* wgsl */`
 output.color = vec4(gammaCorrectOutput(dAlbedo), 1.0);
 #endif
 
+// magnopus patched - start
+#ifdef LOD_PASS
+if (uniform.lod_level == 0) {
+  output.color = vec4f(1.0, 0.0, 0.0, 1.0);
+} else if (uniform.lod_level == 1) {
+  output.color = vec4f(1.0, 1.0, 0.0, 1.0);
+} else if (uniform.lod_level == 2) {
+  output.color = vec4f(0.0, 1.0, 1.0, 1.0);
+} else if (uniform.lod_level == 3) {
+  output.color = vec4f(0.0, 0.0, 1.0, 1.0);
+}
+#endif
+// magnopus patched - end
+
 #ifdef DEBUG_UV0_PASS
 output.color = vec4f(litArgs_albedo , 1.0);
 #endif


### PR DESCRIPTION
[OB-5588] fix: Add shader support for LOD debug visualization in WebGPU

- Added WebGPU shader implementation for LOD debug visualization
