### PR TITLE
[OW-2529] fix: Add crossOrigin option to ply and sog fetches

### DIFF
--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -593,7 +593,7 @@ class PlyParser {
 
         try {
             // either use the fetch request passed in by the application or initiate it ourselves
-            const response = await (asset.file?.contents ?? fetch(url.load));
+            const response = await (asset.file?.contents ?? fetch(url.load, asset.options?.crossOrigin === 'use-credentials' ? { credentials: 'include' } : undefined));
             if (!response || !response.body) {
                 callback('Error loading resource', null);
             } else {

--- a/src/framework/parsers/ply.js
+++ b/src/framework/parsers/ply.js
@@ -593,6 +593,7 @@ class PlyParser {
 
         try {
             // either use the fetch request passed in by the application or initiate it ourselves
+            // Magnopus patched - added crossOrigin option
             const response = await (asset.file?.contents ?? fetch(url.load, asset.options?.crossOrigin === 'use-credentials' ? { credentials: 'include' } : undefined));
             if (!response || !response.body) {
                 callback('Error loading resource', null);

--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -99,6 +99,7 @@ const inflate = async (compressed) => {
 };
 
 const downloadArrayBuffer = async (url, asset) => {
+    // Magnopus patched - added crossOrigin option
     const response = await (asset.file?.contents ?? fetch(url.load, asset.options?.crossOrigin === 'use-credentials' ? { credentials: 'include' } : undefined));
     if (!response) {
         throw new Error('Error loading resource');

--- a/src/framework/parsers/sog-bundle.js
+++ b/src/framework/parsers/sog-bundle.js
@@ -99,7 +99,7 @@ const inflate = async (compressed) => {
 };
 
 const downloadArrayBuffer = async (url, asset) => {
-    const response = await (asset.file?.contents ?? fetch(url.load));
+    const response = await (asset.file?.contents ?? fetch(url.load, asset.options?.crossOrigin === 'use-credentials' ? { credentials: 'include' } : undefined));
     if (!response) {
         throw new Error('Error loading resource');
     }


### PR DESCRIPTION
## Description

Added the crossOrigin option for both ply and sog files, to match what images and meshes have.

## Checklist
- [ ] I have read the [contributing guidelines](https://github.com/playcanvas/engine/blob/master/.github/CONTRIBUTING.md)
- [ ] My code follows the project's coding standards
- [ ] This PR focuses on a single change
